### PR TITLE
fix inconsistent dates on patient page/clinical exam dialog

### DIFF
--- a/app/dashboard/patients/columns.tsx
+++ b/app/dashboard/patients/columns.tsx
@@ -1,20 +1,20 @@
-'use client';
+"use client";
 
-import { Button } from '@/components/ui/button';
-import { capitalizeWord, formatPhoneNumber } from '@/utils/textFormatters';
-import { ColumnDef } from '@tanstack/react-table';
-import { format } from 'date-fns';
-import { ArrowUpDown, MoreHorizontal } from 'lucide-react';
+import { Button } from "@/components/ui/button";
+import { capitalizeWord, formatPhoneNumber } from "@/utils/textFormatters";
+import { ColumnDef } from "@tanstack/react-table";
+import { format, parseISO } from "date-fns";
+import { ArrowUpDown, MoreHorizontal } from "lucide-react";
 
 export const columns: ColumnDef<Patient>[] = [
   {
-    accessorKey: 'surname',
+    accessorKey: "surname",
     header: ({ column }) => {
       return (
         <div>
           <Button
             variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
             className="px-0"
           >
             <span>Surname</span>
@@ -24,18 +24,18 @@ export const columns: ColumnDef<Patient>[] = [
       );
     },
     cell: ({ row }) => {
-      const firstName: string = row.getValue('surname');
+      const firstName: string = row.getValue("surname");
       const formattedSurname = capitalizeWord(firstName);
       return <p className="px-2">{formattedSurname}</p>;
     },
   },
   {
-    accessorKey: 'first_name',
+    accessorKey: "first_name",
     header: ({ column }) => {
       return (
         <Button
           variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           className="px-0"
         >
           First Name
@@ -44,35 +44,35 @@ export const columns: ColumnDef<Patient>[] = [
       );
     },
     cell: ({ row }) => {
-      const firstName: string = row.getValue('first_name');
+      const firstName: string = row.getValue("first_name");
       const formattedFirstName = capitalizeWord(firstName);
       return <p className="px-2">{formattedFirstName}</p>;
     },
   },
   {
-    accessorKey: 'date_of_birth',
+    accessorKey: "date_of_birth",
     header: () => <div className="w-">Date of Birth</div>,
     enableGlobalFilter: false,
     cell: ({ row }) => {
-      const dateOfBirth: string = row.getValue('date_of_birth');
-      return <p className="px-2">{format(new Date(dateOfBirth), 'PP')}</p>;
+      const dateOfBirth: string = row.getValue("date_of_birth");
+      return <p className="px-2">{format(parseISO(dateOfBirth), "PP")}</p>;
     },
   },
   {
-    accessorKey: 'phone',
-    header: 'Phone',
+    accessorKey: "phone",
+    header: "Phone",
     enableGlobalFilter: false,
     cell: ({ row }) => {
-      const phoneNumber: string = row.getValue('phone');
+      const phoneNumber: string = row.getValue("phone");
       return <p className="px-2">{formatPhoneNumber(phoneNumber)}</p>;
     },
   },
   {
-    accessorKey: 'city',
-    header: 'City',
+    accessorKey: "city",
+    header: "City",
     enableGlobalFilter: false,
     cell: ({ row }) => {
-      const city: string = row.getValue('city');
+      const city: string = row.getValue("city");
       return <p className="px-2">{capitalizeWord(city)}</p>;
     },
   },

--- a/components/ExamDetails.tsx
+++ b/components/ExamDetails.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Button } from './ui/button';
+import React from "react";
+import { Button } from "./ui/button";
 import {
   Dialog,
   DialogContent,
@@ -7,11 +7,11 @@ import {
   DialogTitle,
   DialogHeader,
   DialogFooter,
-} from './ui/dialog';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
-import { capitalizeWord } from '@/utils/textFormatters';
-import { calculateAge } from '@/utils/calculators';
-import { format } from 'date-fns';
+} from "./ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import { capitalizeWord } from "@/utils/textFormatters";
+import { calculateAge } from "@/utils/calculators";
+import { format, parseISO } from "date-fns";
 
 type ExamDetailsProps = {
   clinicalAssessment: ClinicalRecord;
@@ -59,11 +59,11 @@ export default function ExamDetails({
             {first_name} {surname}
           </DialogTitle>
           <DialogDescription>
-            {capitalizeWord(sex as string)},
+            {capitalizeWord(sex as string)},{" "}
             {date_of_birth && calculateAge(date_of_birth)} years
           </DialogDescription>
           <DialogDescription>
-            Exam date: {exam_date && format(new Date(exam_date), 'PPP')}
+            Exam date: {exam_date && format(parseISO(exam_date), "PPP")}
           </DialogDescription>
         </DialogHeader>
 
@@ -105,14 +105,14 @@ export default function ExamDetails({
             <h3 className="font-semibold">Temperature</h3>
             <p className="text-sm my-4">{temperature} °C</p>
             <h3 className="font-semibold">Random Blood Sugar</h3>
-            <p className={`text-sm my-4 ${{ random_blood_sugar } && 'italic'}`}>
+            <p className={`text-sm my-4 ${{ random_blood_sugar } && "italic"}`}>
               {random_blood_sugar
                 ? `${random_blood_sugar} mg/dL`
-                : 'not recorded'}
+                : "not recorded"}
             </p>
             <h3 className="font-semibold">Urine</h3>
-            <p className={`text-sm my-4 ${{ urine } && 'italic'}`}>
-              {urine || 'not recorded'}
+            <p className={`text-sm my-4 ${{ urine } && "italic"}`}>
+              {urine || "not recorded"}
             </p>
           </TabsContent>
 
@@ -123,7 +123,7 @@ export default function ExamDetails({
             <p className="text-sm my-4">{on_examination}</p>
             <h3 className="font-semibold">Focused Findings</h3>
             <p className="text-sm my-4">
-              {focused_findings || 'None recorded'}
+              {focused_findings || "None recorded"}
             </p>
           </TabsContent>
 

--- a/components/SoapDetails.tsx
+++ b/components/SoapDetails.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Button } from './ui/button';
+import React from "react";
+import { Button } from "./ui/button";
 import {
   Dialog,
   DialogContent,
@@ -7,11 +7,11 @@ import {
   DialogTitle,
   DialogHeader,
   DialogFooter,
-} from './ui/dialog';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
-import { capitalizeWord } from '@/utils/textFormatters';
-import { calculateAge } from '@/utils/calculators';
-import { format } from 'date-fns';
+} from "./ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import { capitalizeWord } from "@/utils/textFormatters";
+import { calculateAge } from "@/utils/calculators";
+import { format, parseISO } from "date-fns";
 
 type SoapDetailsProps = {
   soapAssesment: SOAP;
@@ -50,11 +50,11 @@ export default function SoapDetails({
             {first_name} {surname}
           </DialogTitle>
           <DialogDescription>
-            {capitalizeWord(sex as string)},{' '}
+            {capitalizeWord(sex as string)},{" "}
             {date_of_birth && calculateAge(date_of_birth)} years
           </DialogDescription>
           <DialogDescription>
-            {/* Exam date: {exam_date && format(new Date(exam_date), 'PPP')} */}
+            {/* Exam date: {exam_date && format(parseISO(exam_date), 'PPP')} */}
           </DialogDescription>
         </DialogHeader>
 
@@ -88,14 +88,14 @@ export default function SoapDetails({
             <h3 className="font-semibold">Temperature</h3>
             <p className="text-sm my-4">{temperature} °C</p>
             <h3 className="font-semibold">Random Blood Sugar</h3>
-            <p className={`text-sm my-4 ${{ random_blood_sugar } && 'italic'}`}>
+            <p className={`text-sm my-4 ${{ random_blood_sugar } && "italic"}`}>
               {random_blood_sugar
                 ? `${random_blood_sugar} mg/dL`
-                : 'not recorded'}
+                : "not recorded"}
             </p>
             <h3 className="font-semibold">Urine</h3>
-            <p className={`text-sm my-4 ${{ urine } && 'italic'}`}>
-              {urine || 'not recorded'}
+            <p className={`text-sm my-4 ${{ urine } && "italic"}`}>
+              {urine || "not recorded"}
             </p>
           </TabsContent>
         </Tabs>


### PR DESCRIPTION
Updates dates that were not using parseISO function from `date-fns` to use it so that dates are consistent.

Related issue:
Closes https://github.com/Full-Stack-Collective/clerkwise/issues/26

Acceptance Criteria:
- [x] check that dates/ages are calculated using the `date-fns` library
- [x] Date of birth should be consistent across the entire app for patients